### PR TITLE
Updated pgMDBconstruct to fulfil PQconnectdbs specifications

### DIFF
--- a/database_interface/src/postgresql_database.cpp
+++ b/database_interface/src/postgresql_database.cpp
@@ -63,8 +63,13 @@ public:
 void PostgresqlDatabase::pgMDBconstruct(std::string host, std::string port, std::string user,
 						 std::string password, std::string dbname )
 {
-  std::string conn_info = "host=" + host + " port=" + port + 
-    " user=" + user + " password=" + password + " dbname=" + dbname;
+  std::string conn_info;
+  //adding empty strings can cause weird things, as they are not expected to be empty
+  if (!host.empty()) conn_info += "host=" + host;
+  if (!port.empty()) conn_info += " port=" + port;
+  if (!user.empty()) conn_info += " user=" + user;
+  if (!password.empty()) conn_info += " password=" + password;
+  if (!dbname.empty()) conn_info += " dbname=" + dbname;
   connection_= PQconnectdb(conn_info.c_str());
   if (PQstatus(connection_)!=CONNECTION_OK) 
   {


### PR DESCRIPTION
PQconnectdbs parser doesn't expect empty values after a keyword [1]. Therefore it doesn't work right, if a configuration string, e.g. the password is empty. Now strings are just added, if they contain sth.

[1] http://www.postgresql.org/docs/9.1/static/libpq-connect.html
