### PR TITLE
Added support for postgesql listen and notfiy

### DIFF
--- a/database_interface/include/database_interface/postgresql_database.h
+++ b/database_interface/include/database_interface/postgresql_database.h
@@ -54,6 +54,13 @@ typedef struct pg_conn PGconn;
 
 namespace database_interface {
 
+//this is used to pass the information stored in a received notification event
+struct Notification {
+  std::string channel;
+  int sending_pid;
+  std::string payload;
+};
+  
 class PostgresqlDatabaseConfig
 {
 private:
@@ -208,6 +215,18 @@ class PostgresqlDatabase
 
   //! Deletes an instance of a DBClass from the database
   bool deleteFromDatabase(DBClass* instance);
+  
+    //! Enables listening to a specified channel
+  bool listenToChannel(std::string channel);
+
+  //! stop listening to a specified channel
+  bool unlistenToChannel(std::string channel);
+
+  //! Checks for a notification
+  bool checkNotify(Notification &no);
+
+  //! Checks for a notification, but waits until something on the socket happens
+  bool checkNotifyIdle(Notification &no);
 
 };
 

--- a/database_interface/include/database_interface/postgresql_database.h
+++ b/database_interface/include/database_interface/postgresql_database.h
@@ -226,7 +226,7 @@ class PostgresqlDatabase
   bool checkNotify(Notification &no);
 
   //! Checks for a notification, but waits until something on the socket happens
-  bool checkNotifyIdle(Notification &no);
+  bool waitForNotify(Notification &no);
 
 };
 

--- a/database_interface/src/postgresql_database.cpp
+++ b/database_interface/src/postgresql_database.cpp
@@ -850,4 +850,83 @@ bool PostgresqlDatabase::deleteFromDatabase(DBClass* instance)
 
 }
 
+/*! Listens to a specified channel using the Postgresql LISTEN-function.*/
+bool PostgresqlDatabase::listenToChannel(std::string channel) {
+  std::string query = "LISTEN " + channel;
+  PGresultAutoPtr result = PQexec(connection_,query.c_str());
+  if (PQresultStatus(*result) != PGRES_COMMAND_OK)
+      {
+          ROS_WARN("LISTEN command failed: %s", PQerrorMessage(connection_));
+          return false;
+      }
+  ROS_INFO("Now listening to channel \"%s\"",channel.c_str());
+  return true;
+}
+
+/*! Stops listening to a specified channel using the Postgresql UNLISTEN-function. */
+bool PostgresqlDatabase::unlistenToChannel(std::string channel)
+{
+  std::string query = "UNLISTEN " + channel + " ;";
+  PGresultAutoPtr result = PQexec(connection_,query.c_str());
+  if (PQresultStatus(*result) != PGRES_COMMAND_OK)
+  {
+    ROS_WARN("UNLISTEN command failed: %s", PQerrorMessage(connection_));
+    return false;
+  }
+  ROS_INFO("Not listening to channel \"%s\" anymore.",channel.c_str());
+  return true;
+}
+
+/*! Checks for a received NOTIFY and returns it. */
+bool PostgresqlDatabase::checkNotify(Notification &no)
+{
+  PGnotify *notify;
+  //check for a notify on the connection
+  PQconsumeInput(connection_);
+  //deal with the received object
+  if ((notify = PQnotifies(connection_)) != NULL)
+  {
+    no.channel = notify->relname;
+    no.sending_pid = notify->be_pid;
+    no.payload = notify->extra;
+    PQfreemem(notify);
+    return true;
+  }
+  else
+  {
+    no.channel = "";
+    no.sending_pid = 0;
+    no.payload = "";
+    PQfreemem(notify);
+    return false;
+  }
+}
+
+/*! Checks for a notify and just exits, if there's an error of a received NOTIFY */
+bool PostgresqlDatabase::checkNotifyIdle(Notification &no)
+{
+  int sock;
+  fd_set input_mask;
+  while (true)
+  {
+      // Sleep until something happens on the connection.
+      sock = PQsocket(connection_);     
+      if (sock < 0)
+      {
+        break;
+      }
+      FD_ZERO(&input_mask);
+      FD_SET(sock, &input_mask);
+
+      if (select(sock + 1, &input_mask, NULL, NULL, NULL) < 0)
+      {
+        ROS_WARN("Select() on the database connection failed: %s\n", strerror(errno));
+        break;
+      }
+      // Check for input
+      if (checkNotify(no)) return true;
+  }
+  return false;
+}
+
 }//namespace


### PR DESCRIPTION
As libpq doesn't support callbacks on a NOTIFY, I added two ways to check for a notify in order to check immediately (checkNotify) or with an idling-until-something-on-the-socket happens. 

I'm not really sure, if the checkNotifyIdle is the best solution for others, but in my application I just create a thread, which runs that function on and on and calls a callback-function if a NOTIFY is retrieved.

I'm also not bound to the Notification struct if you think it's a bad idea.
