### PR TITLE
Add support for YAML-CPP 0.5+.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,5 +11,14 @@ catkin_package(
 
 include_directories(database_interface/include)
 
+# There's no version hint in the yaml-cpp headers, so get the version number
+# from pkg-config.
+find_package(PkgConfig)
+pkg_search_module(yaml-cpp REQUIRED yaml-cpp)
+
+if(NOT ${yaml-cpp_VERSION} VERSION_LESS "0.5")
+add_definitions(-DHAVE_NEW_YAMLCPP)
+endif(NOT ${yaml-cpp_VERSION} VERSION_LESS "0.5")
+
 add_subdirectory(database_interface)
 add_subdirectory(student_database)

--- a/database_interface/include/database_interface/postgresql_database.h
+++ b/database_interface/include/database_interface/postgresql_database.h
@@ -45,6 +45,18 @@
 #include <ros/ros.h>
 #include <yaml-cpp/yaml.h>
 
+#ifdef HAVE_NEW_YAMLCPP
+namespace YAML {
+// The >> operator disappeared in yaml-cpp 0.5, so this function is
+// added to provide support for code written under the yaml-cpp 0.3 API.
+template<typename T>
+void operator >> (const YAML::Node& node, T& i)
+{
+  i = node.as<T>();
+}
+}
+#endif
+
 #include "database_interface/db_class.h"
 #include "database_interface/db_filters.h"
 


### PR DESCRIPTION
The new yaml-cpp API removes the "node >> outputvar;" operator, and
it has a new way of loading documents. There's no version hint in the
library's headers, so I'm getting the version number from pkg-config.

This patch is a port of the ones created by @ktossell for map_server
and other packages.
