### PR TITLE
fix compilation of newer yaml-cpp

### DIFF
--- a/database_interface/include/database_interface/postgresql_database.h
+++ b/database_interface/include/database_interface/postgresql_database.h
@@ -45,18 +45,6 @@
 #include <ros/ros.h>
 #include <yaml-cpp/yaml.h>
 
-#ifdef HAVE_NEW_YAMLCPP
-namespace YAML {
-// The >> operator disappeared in yaml-cpp 0.5, so this function is
-// added to provide support for code written under the yaml-cpp 0.3 API.
-template<typename T>
-void operator >> (const YAML::Node& node, T& i)
-{
-  i = node.as<T>();
-}
-}
-#endif
-
 #include "database_interface/db_class.h"
 #include "database_interface/db_filters.h"
 
@@ -97,14 +85,7 @@ public:
 /*!
  *\brief Loads YAML doc into configuration params. Throws YAML::ParserException if keys missing.
  */
-inline void operator>>(const YAML::Node& node, PostgresqlDatabaseConfig &options)
-{
-  node["password"] >> options.password_;
-  node["user"] >> options.user_;
-  node["host"] >> options.host_;
-  node["port"] >> options.port_;
-  node["dbname"] >> options.dbname_;
-}
+void operator>>(const YAML::Node& node, PostgresqlDatabaseConfig &options);
 
 class PostgresqlDatabase
 {

--- a/database_interface/src/postgresql_database.cpp
+++ b/database_interface/src/postgresql_database.cpp
@@ -44,6 +44,23 @@
 
 namespace database_interface {
 
+void operator>>(const YAML::Node& node, PostgresqlDatabaseConfig &options)
+{
+#ifdef HAVE_NEW_YAMLCPP
+  options.password_ = node["password"].as<std::string>();
+  options.user_ = node["user"].as<std::string>();
+  options.host_ = node["host"].as<std::string>();
+  options.port_ = node["port"].as<std::string>();
+  options.dbname_ = node["dbname"].as<std::string>();
+#else
+  node["password"] >> options.password_;
+  node["user"] >> options.user_;
+  node["host"] >> options.host_;
+  node["port"] >> options.port_;
+  node["dbname"] >> options.dbname_;
+#endif
+}
+
 /*! A little helper class to behave much like an auto ptr for the
   PGresult, except that instead of deleting it when it goes out of
   scope, it calls PQclear() on it.


### PR DESCRIPTION
The version would have to be checked in the dependent if the header checks for the
version
