### PR TITLE
Require PkgConfig for building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(database_interface/include)
 
 # There's no version hint in the yaml-cpp headers, so get the version number
 # from pkg-config.
-find_package(PkgConfig)
+find_package(PkgConfig REQUIRED)
 pkg_search_module(yaml-cpp REQUIRED yaml-cpp)
 
 if(NOT ${yaml-cpp_VERSION} VERSION_LESS "0.5")

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
   <build_depend>libpq-dev</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>yaml-cpp</build_depend>
+  <build_depend>pkg-config</build_depend>
 
   <run_depend>libpq-dev</run_depend>
   <run_depend>roscpp</run_depend>


### PR DESCRIPTION
Suggested fix for https://github.com/ros-interactive-manipulation/sql_database/pull/5#issuecomment-41065751

If nothing else, this will make it clear if the problem is a missing pkg-config or yaml-cpp. The `find_package(PkgConfig)` should be `REQUIRED`, anyway.
